### PR TITLE
feat: auto-select single group for non-owner members

### DIFF
--- a/e2e/groups.spec.ts
+++ b/e2e/groups.spec.ts
@@ -142,4 +142,99 @@ test.describe("Groups UI with Emulator", () => {
 
 		expect(logTypes).not.toContain("error");
 	});
+
+	test("shows single group by default without back button", async ({
+		page,
+	}) => {
+		const joinCode = "single-group-member";
+		const groupName = "Single Group Member";
+		const ownerEmail = "owner-member@birdwatcher.test";
+		const ownerPassword = "password123";
+		const memberEmail = "member-only@birdwatcher.test";
+		const memberPassword = "password456";
+
+		// 1. Owner creates a group
+		await createTestUser(ownerEmail, ownerPassword, "GroupOwner");
+		const { signInInBrowser, signOutInBrowser } = await import(
+			"./helpers/browser-auth"
+		);
+
+		await signOutInBrowser(page);
+		await signInInBrowser(page, ownerEmail, ownerPassword);
+
+		await expect(page.getByText("Your Groups")).toBeVisible({ timeout: 10000 });
+
+		await page.getByLabel("Group Name:").fill(groupName);
+		await page.getByLabel("Unique Join Code:").fill(joinCode);
+		await page.getByRole("button", { name: "Create Group" }).click();
+
+		await expect(page.getByText(groupName)).toBeVisible({ timeout: 10000 });
+
+		// 2. Sign out owner and create a non-owner member
+		await signOutInBrowser(page);
+		await createTestUser(memberEmail, memberPassword);
+		await signInInBrowser(page, memberEmail, memberPassword);
+
+		// 3. Member joins the group
+		await page.goto(`/?group=${joinCode}`);
+
+		// Wait for auto-join
+		await expect(page).not.toHaveURL(/group=/, { timeout: 10000 });
+
+		// 4. Member should see the group view directly (not the list)
+		await expect(page.getByRole("heading", { name: groupName })).toBeVisible();
+		await expect(page.getByText(/Members \(2\)/)).toBeVisible();
+
+		// 5. Verify no back button and no "Your Groups" list
+		await expect(
+			page.getByRole("button", { name: "← Back" }),
+		).not.toBeVisible();
+		await expect(page.getByText("Your Groups")).not.toBeVisible();
+
+		expect(logTypes).not.toContain("error");
+	});
+
+	test("owner with single group sees back button and group list", async ({
+		page,
+	}) => {
+		const joinCode = "single-group-owner";
+		const groupName = "Single Group Owner";
+
+		// 1. Owner creates a group
+		const ownerEmail = "owner-single@birdwatcher.test";
+		const ownerPassword = "password789";
+
+		await createTestUser(ownerEmail, ownerPassword, "OwnerUser");
+		const { signInInBrowser, signOutInBrowser } = await import(
+			"./helpers/browser-auth"
+		);
+
+		await signOutInBrowser(page);
+		await signInInBrowser(page, ownerEmail, ownerPassword);
+
+		await expect(page.getByText("Your Groups")).toBeVisible({ timeout: 10000 });
+
+		await page.getByLabel("Group Name:").fill(groupName);
+		await page.getByLabel("Unique Join Code:").fill(joinCode);
+		await page.getByRole("button", { name: "Create Group" }).click();
+
+		await expect(page.getByText(groupName)).toBeVisible({ timeout: 10000 });
+
+		// 2. Owner should see group list (not auto-selected)
+		await expect(page.getByText("Your Groups")).toBeVisible();
+		await expect(page.getByText(groupName)).toBeVisible();
+
+		// 3. Click group to view members
+		const groupItem = page.getByRole("button", { name: new RegExp(groupName) });
+		await groupItem.click();
+
+		// 4. Verify back button is shown for owner
+		await expect(page.getByRole("button", { name: "← Back" })).toBeVisible();
+
+		// 5. Click back and verify group list reappears
+		await page.getByRole("button", { name: "← Back" }).click();
+		await expect(page.getByText("Your Groups")).toBeVisible();
+
+		expect(logTypes).not.toContain("error");
+	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,63 @@
-import { useState } from "react";
+import { collection, onSnapshot, query, where } from "firebase/firestore";
+import { useEffect, useState } from "react";
 import { GroupList } from "./components/Groups/GroupList";
 import { GroupMembers } from "./components/Groups/GroupMembers";
 import { Login } from "./components/Login";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import { db } from "./lib/firebase";
 import type { Group } from "./types";
 
 function AuthenticatedApp() {
 	const { currentUser, logout } = useAuth();
 	const [selectedGroup, setSelectedGroup] = useState<Group | null>(null);
+	const [groups, setGroups] = useState<Group[]>([]);
+
+	// Fetch user's groups
+	useEffect(() => {
+		if (!currentUser) {
+			setGroups([]);
+			return;
+		}
+
+		const q = query(
+			collection(db, "groups"),
+			where("memberIds", "array-contains", currentUser.uid),
+		);
+
+		const unsubscribe = onSnapshot(
+			q,
+			(snapshot) => {
+				const userGroups = snapshot.docs.map((d) => ({
+					id: d.id,
+					...(d.data() as Omit<Group, "id">),
+				})) as Group[];
+				setGroups(userGroups);
+
+				// Auto-select if user is not owner of any group and has exactly 1 group
+				const isOwnerOfAny = userGroups.some(
+					(g) => g.ownerId === currentUser.uid,
+				);
+				if (!isOwnerOfAny && userGroups.length === 1 && !selectedGroup) {
+					setSelectedGroup(userGroups[0]);
+				}
+			},
+			(err) => {
+				console.error("Failed to fetch groups:", err);
+			},
+		);
+
+		return () => {
+			unsubscribe();
+		};
+	}, [currentUser, selectedGroup]);
 
 	if (!currentUser) {
 		return <Login />;
 	}
+
+	// Check if user owns any groups
+	const isOwnerOfAny = groups.some((g) => g.ownerId === currentUser.uid);
+	const isSingleGroupNonOwner = !isOwnerOfAny && groups.length === 1;
 
 	return (
 		<div className="app-container">
@@ -38,7 +84,9 @@ function AuthenticatedApp() {
 					{selectedGroup ? (
 						<GroupMembers
 							group={selectedGroup}
-							onBack={() => setSelectedGroup(null)}
+							onBack={
+								isSingleGroupNonOwner ? undefined : () => setSelectedGroup(null)
+							}
 						/>
 					) : (
 						<GroupList onSelectGroup={setSelectedGroup} />

--- a/src/components/Groups/GroupMembers.tsx
+++ b/src/components/Groups/GroupMembers.tsx
@@ -4,7 +4,7 @@ import type { Group, UserProfile } from "../../types";
 
 interface GroupMembersProps {
 	group: Group;
-	onBack: () => void;
+	onBack?: () => void;
 }
 
 export function GroupMembers({ group, onBack }: GroupMembersProps) {
@@ -43,9 +43,11 @@ export function GroupMembers({ group, onBack }: GroupMembersProps) {
 	return (
 		<div className="group-members-container">
 			<div className="group-header">
-				<button type="button" onClick={onBack} className="back-button">
-					← Back
-				</button>
+				{onBack && (
+					<button type="button" onClick={onBack} className="back-button">
+						← Back
+					</button>
+				)}
 				<h2>{group.name}</h2>
 				<small className="join-code">Join Code: {group.joinCode}</small>
 			</div>


### PR DESCRIPTION
## Changes
- If user owns any group: show group list with selection
- If user is not owner of any group and has exactly 1 group: show only that group view (no back button, no list)
- Update GroupMembers to accept optional onBack prop

## Testing
- ✅ All unit tests passing (11 passed)
- ✅ All E2E tests passing (8 passed including 2 new tests)
- ✅ Build succeeds
- ✅ Linting passes

## New E2E Tests
- Test: "shows single group by default without back button" - Verifies non-owner with 1 group sees group view directly
- Test: "owner with single group sees back button and group list" - Verifies owner behavior is unchanged