### PR TITLE
feat(user): add compare view for sightings comparison

### DIFF
--- a/e2e/user-compare.spec.ts
+++ b/e2e/user-compare.spec.ts
@@ -85,12 +85,16 @@ test.describe("User Comparison", () => {
 		});
 
 		// 2. Create User B and seed its stats (this will switch Node auth to User B)
-		const emailB = "userb@example.com";
-		userB = await createTestUser(emailB, "password123", "UserB");
+		const credentialsB = getTestUserCredentials();
+		userB = await createTestUser(
+			credentialsB.email,
+			credentialsB.password,
+			"UserB",
+		);
 		await seedUserProfile({
 			id: userB.uid,
 			displayName: "UserB",
-			email: emailB,
+			email: credentialsB.email,
 			photoURL: null,
 		});
 

--- a/e2e/user-compare.spec.ts
+++ b/e2e/user-compare.spec.ts
@@ -57,7 +57,7 @@ test.describe("User Comparison", () => {
 		await navigateToUserView(page);
 
 		// Click Compare button
-		await page.getByRole("link", { name: "Compare" }).click();
+		await page.getByTestId("compare-button").click();
 		await expect(page).toHaveURL(/\/compare/);
 
 		// Select Year 2024 and Month January
@@ -113,7 +113,7 @@ test.describe("User Comparison", () => {
 		await page.locator(".member-item").filter({ hasText: "UserB" }).click();
 
 		// Click Compare
-		await page.getByRole("link", { name: "Compare" }).click();
+		await page.getByTestId("compare-button").click();
 
 		await page.locator("#compare-year").selectOption("2024");
 		await page.locator("#compare-month").selectOption(""); // Any/Whole year

--- a/e2e/user-compare.spec.ts
+++ b/e2e/user-compare.spec.ts
@@ -110,7 +110,7 @@ test.describe("User Comparison", () => {
 
 		// Verify lists are present correctly
 		const listContainer = page.locator(".compare-results");
-		
+
 		// Order: I have, They have, Both have
 		const sectionTitles = listContainer.locator("h4");
 		await expect(sectionTitles.nth(0)).toContainText("You have, they don't");

--- a/e2e/user-compare.spec.ts
+++ b/e2e/user-compare.spec.ts
@@ -24,6 +24,12 @@ test.describe("User Comparison", () => {
 			credentials.password,
 			"Tester",
 		);
+		await seedUserProfile({
+			id: testUser.uid,
+			displayName: "Tester",
+			email: credentials.email,
+			photoURL: null,
+		});
 
 		await page.goto("/");
 		const { signInInBrowser } = await import("./helpers/browser-auth");
@@ -32,18 +38,19 @@ test.describe("User Comparison", () => {
 	});
 
 	test("performs self-comparison correctly", async ({ page }) => {
-		// Seed stats: 2024 has Varis and Sinisorsa. Jan has only Sinisorsa.
-		// So Varis is missing in Jan.
-		await seedUserStats(testUser.uid, {
-			"2024": ["sinisorsa", "varis"],
-			"2024-01": ["sinisorsa"],
-		});
-
 		// Ensure user is in a group
 		await seedGroup({
 			name: "Compare Group",
 			ownerId: testUser.uid,
 			memberIds: [testUser.uid],
+		});
+
+		// Seed stats: 2024 has Varis and Sinisorsa. Jan has only Sinisorsa.
+		// So Varis is missing in Jan.
+		// NOTE: testUser is authenticated in Node from beforeEach
+		await seedUserStats(testUser.uid, {
+			"2024": ["sinisorsa", "varis"],
+			"2024-01": ["sinisorsa"],
 		});
 
 		await page.reload();
@@ -71,6 +78,13 @@ test.describe("User Comparison", () => {
 	});
 
 	test("performs cross-user comparison correctly", async ({ page }) => {
+		// 1. Seed stats for testUser while authenticated as testUser?
+		// Wait, Node is currently authenticated as testUser from beforeEach.
+		await seedUserStats(testUser.uid, {
+			"2024": ["sinisorsa", "varis"],
+		});
+
+		// 2. Create User B and seed its stats (this will switch Node auth to User B)
 		const emailB = "userb@example.com";
 		userB = await createTestUser(emailB, "password123", "UserB");
 		await seedUserProfile({
@@ -80,20 +94,16 @@ test.describe("User Comparison", () => {
 			photoURL: null,
 		});
 
+		// Them: Varis, Telkkä.
+		await seedUserStats(userB.uid, {
+			"2024": ["varis", "telkka"],
+		});
+
 		const groupName = "Shared Group";
 		await seedGroup({
 			name: groupName,
 			ownerId: testUser.uid,
 			memberIds: [testUser.uid, userB.uid],
-		});
-
-		// Me: Sinisorsa, Varis. Them: Varis, Telkkä.
-		// Result: You have (Sinisorsa), They have (Telkkä), Both (Varis).
-		await seedUserStats(testUser.uid, {
-			"2024": ["sinisorsa", "varis"],
-		});
-		await seedUserStats(userB.uid, {
-			"2024": ["varis", "telkka"],
 		});
 
 		await page.reload();

--- a/e2e/user-compare.spec.ts
+++ b/e2e/user-compare.spec.ts
@@ -1,0 +1,131 @@
+import { navigateToUserView } from "./helpers/actions";
+import { createTestUser, getTestUserCredentials } from "./helpers/auth-helpers";
+import {
+	seedGroup,
+	seedUserProfile,
+	seedUserStats,
+} from "./helpers/firestore-helpers";
+import { expect, test } from "./helpers/fixtures";
+
+test.describe("User Comparison", () => {
+	// biome-ignore lint/suspicious/noExplicitAny: Need any for test user
+	let testUser: any;
+	// biome-ignore lint/suspicious/noExplicitAny: Need any for test user
+	let userB: any;
+
+	test.beforeEach(async ({ page }) => {
+		await page.addInitScript(() => {
+			localStorage.setItem("language", "en");
+		});
+
+		const credentials = getTestUserCredentials();
+		testUser = await createTestUser(
+			credentials.email,
+			credentials.password,
+			"Tester",
+		);
+
+		await page.goto("/");
+		const { signInInBrowser } = await import("./helpers/browser-auth");
+		await signInInBrowser(page, credentials.email, credentials.password);
+		await expect(page.getByText("Your Groups")).toBeVisible();
+	});
+
+	test("performs self-comparison correctly", async ({ page }) => {
+		// Seed stats: 2024 has Varis and Sinisorsa. Jan has only Sinisorsa.
+		// So Varis is missing in Jan.
+		await seedUserStats(testUser.uid, {
+			"2024": ["sinisorsa", "varis"],
+			"2024-01": ["sinisorsa"],
+		});
+
+		// Ensure user is in a group
+		await seedGroup({
+			name: "Compare Group",
+			ownerId: testUser.uid,
+			memberIds: [testUser.uid],
+		});
+
+		await page.reload();
+		await navigateToUserView(page);
+
+		// Click Compare button
+		await page.getByRole("link", { name: "Compare" }).click();
+		await expect(page).toHaveURL(/\/compare/);
+
+		// Select Year 2024 and Month January
+		await page.locator("#compare-year").selectOption("2024");
+		await page.locator("#compare-month").selectOption("0"); // January
+
+		// Verify "Seen this month" (Sinisorsa)
+		const seenSection = page.locator(".compare-list", {
+			hasText: "Seen this month",
+		});
+		await expect(seenSection).toContainText("Sinisorsa");
+
+		// Verify "Missing this month" (Varis)
+		const missingSection = page.locator(".compare-list", {
+			hasText: "Missing this month",
+		});
+		await expect(missingSection).toContainText("Varis");
+	});
+
+	test("performs cross-user comparison correctly", async ({ page }) => {
+		const emailB = "userb@example.com";
+		userB = await createTestUser(emailB, "password123", "UserB");
+		await seedUserProfile({
+			id: userB.uid,
+			displayName: "UserB",
+			email: emailB,
+			photoURL: null,
+		});
+
+		const groupName = "Shared Group";
+		await seedGroup({
+			name: groupName,
+			ownerId: testUser.uid,
+			memberIds: [testUser.uid, userB.uid],
+		});
+
+		// Me: Sinisorsa, Varis. Them: Varis, Telkkä.
+		// Result: You have (Sinisorsa), They have (Telkkä), Both (Varis).
+		await seedUserStats(testUser.uid, {
+			"2024": ["sinisorsa", "varis"],
+		});
+		await seedUserStats(userB.uid, {
+			"2024": ["varis", "telkka"],
+		});
+
+		await page.reload();
+		// Navigate to UserB's profile via Members tab
+		await page.getByRole("link", { name: new RegExp(groupName) }).click();
+		await page.getByRole("button", { name: "Members" }).click();
+		await page.locator(".member-item").filter({ hasText: "UserB" }).click();
+
+		// Click Compare
+		await page.getByRole("link", { name: "Compare" }).click();
+
+		await page.locator("#compare-year").selectOption("2024");
+		await page.locator("#compare-month").selectOption(""); // Any/Whole year
+
+		// Verify lists are present correctly
+		const listContainer = page.locator(".compare-results");
+		
+		// Order: I have, They have, Both have
+		const sectionTitles = listContainer.locator("h4");
+		await expect(sectionTitles.nth(0)).toContainText("You have, they don't");
+		await expect(sectionTitles.nth(1)).toContainText("They have, you don't");
+		await expect(sectionTitles.nth(2)).toContainText("Both have");
+
+		// Values
+		await expect(
+			page.locator(".compare-list", { hasText: "You have, they don't" }),
+		).toContainText("Sinisorsa");
+		await expect(
+			page.locator(".compare-list", { hasText: "They have, you don't" }),
+		).toContainText("Telkkä");
+		await expect(
+			page.locator(".compare-list", { hasText: "Both have" }),
+		).toContainText("Varis");
+	});
+});

--- a/e2e/user-view.spec.ts
+++ b/e2e/user-view.spec.ts
@@ -230,8 +230,8 @@ test.describe("User View", () => {
 		// Current year is based on run time, so "Yearly" might be 0 if currentYear != 2024.
 		// But "Total" should be 1.
 		await expect(page.getByText(/Total/i)).toBeVisible();
-		// We expect "1" to be visible in stats
-		await expect(page.locator(".stat-value").getByText("1")).toBeVisible();
+		// We expect "1" to be visible in total stats
+		await expect(page.getByTestId("stat-total")).toHaveText("1");
 
 		// 5. Check Data (March 2024)
 		// Open filters

--- a/e2e/user-view.spec.ts
+++ b/e2e/user-view.spec.ts
@@ -173,14 +173,15 @@ test.describe("User View", () => {
 		// We need to create User B.
 		const emailB = "userb@example.com";
 		const userB = await createTestUser(emailB, "password123", "UserB");
-
-		// Ensure User B has profile
 		await seedUserProfile({
 			id: userB.uid,
 			displayName: userB.displayName,
 			email: userB.email,
 			photoURL: userB.photoURL,
 		});
+
+		// Seed stats for User B while Node is authenticated as User B
+		await seedUserStats(userB.uid, { "2024-03": ["harakka"] });
 
 		const groupName = "Shared Group";
 		const joinCode = "shared-group-1";
@@ -205,9 +206,6 @@ test.describe("User View", () => {
 				createdAt: Date.now(),
 			},
 		]);
-
-		// Seed stats
-		await seedUserStats(userB.uid, { "2024-03": ["harakka"] });
 
 		// Test Flow:
 		// 1. Go to Group

--- a/e2e/user-view.spec.ts
+++ b/e2e/user-view.spec.ts
@@ -171,8 +171,12 @@ test.describe("User View", () => {
 		// Setup: Seed a group with another user and their sightings
 		// Tester (testUser) is ALREADY created in BeforeEach.
 		// We need to create User B.
-		const emailB = "userb@example.com";
-		const userB = await createTestUser(emailB, "password123", "UserB");
+		const credentialsB = getTestUserCredentials();
+		const userB = await createTestUser(
+			credentialsB.email,
+			credentialsB.password,
+			"UserB",
+		);
 		await seedUserProfile({
 			id: userB.uid,
 			displayName: userB.displayName,

--- a/src/App.css
+++ b/src/App.css
@@ -1390,4 +1390,119 @@ div.sighting-bg {
 
 .user-profile-summary h2 {
 	margin: 0;
+	margin-bottom: 0.5rem;
+}
+
+.user-profile-info {
+	display: flex;
+	flex-direction: column;
+}
+
+.user-actions {
+	display: flex;
+	gap: 0.5rem;
+}
+
+/* Compare View */
+.compare-view {
+	display: flex;
+	flex-direction: column;
+	gap: 2rem;
+}
+
+.compare-header {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--border-color);
+	padding-bottom: 1rem;
+}
+
+.compare-filters {
+	display: flex;
+	gap: 1rem;
+	flex-wrap: wrap;
+	background: var(--bg-secondary);
+	padding: 1rem;
+	border-radius: 8px;
+	border: 1px solid var(--border-color);
+}
+
+.filter-group {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	flex: 1;
+	min-width: 150px;
+}
+
+.filter-group label {
+	font-size: 0.9rem;
+	font-weight: 500;
+	color: var(--text-secondary);
+}
+
+.filter-group select {
+	padding: 0.5rem;
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+}
+
+.compare-content-container {
+	display: flex;
+	flex-direction: column;
+	gap: 2rem;
+}
+
+.compare-results {
+	display: flex;
+	gap: 2rem;
+	flex-wrap: wrap;
+}
+
+.compare-results > .compare-list {
+	flex: 1;
+	min-width: 250px;
+	background: var(--bg-tertiary);
+	border-radius: 8px;
+	padding: 1rem;
+	border: 1px solid var(--border-color);
+}
+
+.compare-list h4 {
+	margin-top: 0;
+	margin-bottom: 1rem;
+	color: var(--text-primary);
+	font-size: 1.1rem;
+	padding-bottom: 0.5rem;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.bird-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.bird-list li {
+	padding: 0.5rem;
+	background: var(--bg-secondary);
+	border-radius: 4px;
+	font-size: 0.95rem;
+}
+
+.no-birds-text {
+	color: var(--text-secondary);
+	font-style: italic;
+	font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+	.compare-results {
+		flex-direction: column;
+	}
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,9 @@ const SightingDetails = lazy(() =>
 		default: m.SightingDetails,
 	})),
 );
+const UserCompare = lazy(() =>
+	import("./components/UserCompare").then((m) => ({ default: m.UserCompare })),
+);
 
 function AuthenticatedApp() {
 	const { currentUser, logout } = useAuth();
@@ -101,6 +104,10 @@ function AuthenticatedApp() {
 							<Route
 								path="/groups/:groupId/members/:userId/sightings/:sightingId"
 								element={<SightingDetails />}
+							/>
+							<Route
+								path="/groups/:groupId/members/:userId/compare"
+								element={<UserCompare />}
 							/>
 							<Route path="*" element={<Navigate to="/" replace />} />
 						</Routes>

--- a/src/components/AddSighting.tsx
+++ b/src/components/AddSighting.tsx
@@ -183,7 +183,7 @@ export default function AddSighting({
 		};
 
 		try {
-			if (isEditing && initialSighting && initialSighting.id) {
+			if (isEditing && initialSighting?.id) {
 				await updateSighting(initialSighting.id, sightingData);
 			} else {
 				await addSighting(sightingData);

--- a/src/components/SightingsList.tsx
+++ b/src/components/SightingsList.tsx
@@ -161,24 +161,21 @@ export function SightingsList({
 								{/* Bottom Metadata */}
 								<div className="sighting-meta-bottom">
 									<h3 className="sighting-bird-name">{birdName}</h3>
-									{showMemberName &&
-										members &&
-										members.get(sighting.userId) && (
-											<div className="sighting-user-avatar">
-												{members.get(sighting.userId)?.photoURL ? (
-													<img
-														src={
-															members.get(sighting.userId)?.photoURL ||
-															undefined
-														}
-														alt={members.get(sighting.userId)?.displayName}
-														className="avatar-img"
-													/>
-												) : (
-													<span className="avatar-fallback">👤</span>
-												)}
-											</div>
-										)}
+									{showMemberName && members?.get(sighting.userId) && (
+										<div className="sighting-user-avatar">
+											{members.get(sighting.userId)?.photoURL ? (
+												<img
+													src={
+														members.get(sighting.userId)?.photoURL || undefined
+													}
+													alt={members.get(sighting.userId)?.displayName}
+													className="avatar-img"
+												/>
+											) : (
+												<span className="avatar-fallback">👤</span>
+											)}
+										</div>
+									)}
 								</div>
 							</Link>
 						</li>

--- a/src/components/UserCompare.tsx
+++ b/src/components/UserCompare.tsx
@@ -1,0 +1,226 @@
+import type React from "react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+import { getUserProfile, getUserStats } from "../lib/firestore";
+import type { UserProfile } from "../types";
+
+export function UserCompare() {
+	const { t, i18n } = useTranslation();
+	const { userId } = useParams<{ userId: string }>();
+	const { currentUser } = useAuth();
+
+	const [targetUser, setTargetUser] = useState<UserProfile | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const now = new Date();
+	const [selectedYear, setSelectedYear] = useState(now.getFullYear());
+	const [selectedMonth, setSelectedMonth] = useState<number | null>(
+		now.getMonth(),
+	);
+
+	const [myStats, setMyStats] = useState<Record<string, string[]>>({});
+	const [theirStats, setTheirStats] = useState<Record<string, string[]>>({});
+
+	// Derived filter options
+	const [availableYears, setAvailableYears] = useState<number[]>([]);
+	const [availableMonths, setAvailableMonths] = useState<
+		{ value: number | null; label: string }[]
+	>([]);
+
+	useEffect(() => {
+		const currentYear = new Date().getFullYear();
+		setAvailableYears(Array.from({ length: 5 }, (_, i) => currentYear - i));
+
+		setAvailableMonths([
+			{ value: null, label: t("common.any") },
+			...Array.from({ length: 12 }, (_, i) => ({
+				value: i,
+				label: new Date(2000, i, 1).toLocaleDateString(i18n.language, {
+					month: "long",
+				}),
+			})),
+		]);
+	}, [i18n.language, t]);
+
+	useEffect(() => {
+		let isMounted = true;
+
+		async function fetchData() {
+			if (!currentUser || !userId) return;
+			setLoading(true);
+			try {
+				const [targetProfile, myStatsData, theirStatsData] = await Promise.all([
+					getUserProfile(userId),
+					getUserStats(currentUser.uid),
+					userId !== currentUser.uid
+						? getUserStats(userId)
+						: Promise.resolve({}),
+				]);
+
+				if (isMounted) {
+					if (!targetProfile) {
+						setError(t("errors.userNotFound"));
+					} else {
+						setTargetUser(targetProfile);
+						setMyStats(myStatsData);
+						if (userId !== currentUser.uid) {
+							setTheirStats(theirStatsData);
+						}
+					}
+					setLoading(false);
+				}
+			} catch (err) {
+				console.error(err);
+				if (isMounted) {
+					setError(t("errors.unknown"));
+					setLoading(false);
+				}
+			}
+		}
+
+		fetchData();
+
+		return () => {
+			isMounted = false;
+		};
+	}, [userId, currentUser, t]);
+
+	if (loading) return <div className="loading">{t("common.loading")}</div>;
+	if (error || !targetUser)
+		return <div className="error-message">{error || t("errors.unknown")}</div>;
+
+	const isSelf = currentUser?.uid === userId;
+	const yearKey = selectedYear.toString();
+	const monthKey =
+		selectedMonth !== null
+			? `${selectedYear}-${String(selectedMonth + 1).padStart(2, "0")}`
+			: null;
+
+	const renderList = (title: string, birds: string[]) => {
+		// Sort birds alphabetically
+		const sorted = [...birds].sort((a, b) => {
+			const nameA = t(`birds.${a}`, a);
+			const nameB = t(`birds.${b}`, b);
+			return nameA.localeCompare(nameB);
+		});
+
+		return (
+			<div className="compare-list">
+				<h4>
+					{title} ({sorted.length})
+				</h4>
+				{sorted.length === 0 ? (
+					<p className="no-birds-text">{t("compare.noBirds")}</p>
+				) : (
+					<ul className="bird-list">
+						{sorted.map((birdId) => (
+							<li key={birdId}>{t(`birds.${birdId}`, birdId)}</li>
+						))}
+					</ul>
+				)}
+			</div>
+		);
+	};
+
+	let compareContent: React.ReactNode;
+
+	if (isSelf) {
+		if (selectedMonth === null) {
+			compareContent = (
+				<p className="compare-prompt">{t("compare.selectMonthPrompt")}</p>
+			);
+		} else {
+			const yearBirds = new Set(myStats[yearKey] || []);
+			const monthBirds = new Set(myStats[monthKey as string] || []);
+
+			const missingThisMonth = [...yearBirds].filter(
+				(bird) => !monthBirds.has(bird),
+			);
+			const seenThisMonth = [...monthBirds];
+
+			compareContent = (
+				<div className="compare-results">
+					{renderList(t("compare.missingThisMonth"), missingThisMonth)}
+					{renderList(t("compare.seenThisMonth"), seenThisMonth)}
+				</div>
+			);
+		}
+	} else {
+		let myBirdsSet: Set<string>;
+		let theirBirdsSet: Set<string>;
+
+		if (selectedMonth !== null) {
+			myBirdsSet = new Set(myStats[monthKey as string] || []);
+			theirBirdsSet = new Set(theirStats[monthKey as string] || []);
+		} else {
+			myBirdsSet = new Set(myStats[yearKey] || []);
+			theirBirdsSet = new Set(theirStats[yearKey] || []);
+		}
+
+		const myBirds = [...myBirdsSet];
+		const theirBirds = [...theirBirdsSet];
+
+		const iHaveTheyDont = myBirds.filter((b) => !theirBirdsSet.has(b));
+		const theyHaveIDont = theirBirds.filter((b) => !myBirdsSet.has(b));
+		const bothHave = myBirds.filter((b) => theirBirdsSet.has(b));
+
+		compareContent = (
+			<div className="compare-results tri-column">
+				{renderList(t("compare.youHaveTheyDont"), iHaveTheyDont)}
+				{renderList(t("compare.theyHaveYouDont"), theyHaveIDont)}
+				{renderList(t("compare.bothHave"), bothHave)}
+			</div>
+		);
+	}
+
+	return (
+		<div className="compare-view">
+			<div className="compare-header">
+				<h2>
+					{isSelf
+						? t("compare.titleSelf")
+						: t("compare.titleOther", { name: targetUser.displayName })}
+				</h2>
+			</div>
+
+			<div className="compare-filters">
+				<div className="filter-group">
+					<label htmlFor="compare-year">{t("common.year")}</label>
+					<select
+						id="compare-year"
+						value={selectedYear}
+						onChange={(e) => setSelectedYear(Number(e.target.value))}
+					>
+						{availableYears.map((year) => (
+							<option key={year} value={year}>
+								{year}
+							</option>
+						))}
+					</select>
+				</div>
+				<div className="filter-group">
+					<label htmlFor="compare-month">{t("common.month")}</label>
+					<select
+						id="compare-month"
+						value={selectedMonth === null ? "" : selectedMonth}
+						onChange={(e) => {
+							const val = e.target.value;
+							setSelectedMonth(val === "" ? null : Number(val));
+						}}
+					>
+						{availableMonths.map((m) => (
+							<option key={m.label} value={m.value === null ? "" : m.value}>
+								{m.label}
+							</option>
+						))}
+					</select>
+				</div>
+			</div>
+
+			<div className="compare-content-container">{compareContent}</div>
+		</div>
+	);
+}

--- a/src/components/UserStats.tsx
+++ b/src/components/UserStats.tsx
@@ -35,17 +35,23 @@ export function UserStats({ stats }: UserStatsProps) {
 				<div className="stat-label">
 					{currentMonthLabel} {currentYear}
 				</div>
-				<div className="stat-value">{monthUnique}</div>
+				<div className="stat-value" data-testid="stat-month">
+					{monthUnique}
+				</div>
 			</div>
 			<div className="stat-item">
 				<div className="stat-label">
 					{t("common.year")} {currentYear}
 				</div>
-				<div className="stat-value">{yearUnique}</div>
+				<div className="stat-value" data-testid="stat-year">
+					{yearUnique}
+				</div>
 			</div>
 			<div className="stat-item">
 				<div className="stat-label">{t("common.total")}</div>
-				<div className="stat-value">{allTimeUnique}</div>
+				<div className="stat-value" data-testid="stat-total">
+					{allTimeUnique}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/UserView.tsx
+++ b/src/components/UserView.tsx
@@ -234,6 +234,7 @@ export function UserView() {
 							<Link
 								to={`/groups/${groupId}/members/${userId}/compare`}
 								className="secondary-button"
+								data-testid="compare-button"
 							>
 								{t("userView.compare")}
 							</Link>

--- a/src/components/UserView.tsx
+++ b/src/components/UserView.tsx
@@ -1,7 +1,7 @@
 import type { QueryDocumentSnapshot } from "firebase/firestore";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 import { useAvailableSpecies } from "../hooks/useAvailableSpecies";
 import {
@@ -18,7 +18,7 @@ import { UserStats } from "./UserStats";
 
 export function UserView() {
 	const { t, i18n } = useTranslation();
-	const { userId } = useParams<{ userId: string }>();
+	const { groupId, userId } = useParams<{ groupId: string; userId: string }>();
 	const { currentUser } = useAuth();
 
 	const [user, setUser] = useState<UserProfile | null>(null);
@@ -223,12 +223,22 @@ export function UserView() {
 							className="user-avatar-large"
 						/>
 					)}
-					<h2 data-testid="user-view-heading">
-						{user.displayName}
-						{userId === currentUser?.uid && (
-							<span className="you-badge">{t("groups.you")}</span>
-						)}
-					</h2>
+					<div className="user-profile-info">
+						<h2 data-testid="user-view-heading">
+							{user.displayName}
+							{userId === currentUser?.uid && (
+								<span className="you-badge">{t("groups.you")}</span>
+							)}
+						</h2>
+						<div className="user-actions">
+							<Link
+								to={`/groups/${groupId}/members/${userId}/compare`}
+								className="secondary-button"
+							>
+								{t("userView.compare")}
+							</Link>
+						</div>
+					</div>
 				</div>
 				<UserStats stats={stats} />
 			</div>

--- a/src/components/UserView.tsx
+++ b/src/components/UserView.tsx
@@ -215,7 +215,7 @@ export function UserView() {
 			<div className="user-view-header">
 				{/* Removed Back button as Breadcrumbs handle navigation */}
 
-				<div className="user-profile-summary">
+				<div className="user-info">
 					{user.photoURL && (
 						<img
 							src={user.photoURL}

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -251,7 +251,7 @@ export const getUserProfile = async (
 ): Promise<UserProfile | null> => {
 	const docRef = doc(db, "users", userId);
 	const snapshot = await getDoc(docRef);
-	if (snapshot && snapshot.exists()) {
+	if (snapshot?.exists()) {
 		return snapshot.data() as UserProfile;
 	}
 	return null;
@@ -530,7 +530,7 @@ export const getSighting = async (
 	const docRef = doc(db, "sightings", sightingId);
 	const snapshot = await getDoc(docRef);
 
-	if (snapshot && snapshot.exists()) {
+	if (snapshot?.exists()) {
 		return { id: snapshot.id, ...snapshot.data() } as Sighting;
 	}
 	return null;

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -606,7 +606,7 @@ export const recalculateGroupStats = async (
 ): Promise<void> => {
 	const groupRef = doc(db, "groups", groupId);
 	const groupDoc = await getDoc(groupRef);
-	if (!groupDoc || !groupDoc.exists()) return;
+	if (!groupDoc?.exists()) return;
 
 	const memberIds = groupDoc.data()?.memberIds || [];
 	if (memberIds.length === 0) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -29,7 +29,20 @@
 	"userView": {
 		"sightings": "Sightings",
 		"noSightings": "No sightings found for this period",
-		"failedToLoad": "Failed to load sightings"
+		"failedToLoad": "Failed to load sightings",
+		"compare": "Compare"
+	},
+	"compare": {
+		"title": "Compare",
+		"titleSelf": "Compare to Whole Year",
+		"titleOther": "Compare with {{name}}",
+		"missingThisMonth": "Missing this month",
+		"seenThisMonth": "Seen this month",
+		"youHaveTheyDont": "You have, they don't",
+		"theyHaveYouDont": "They have, you don't",
+		"bothHave": "Both have",
+		"selectMonthPrompt": "Please select a month to compare with the whole year.",
+		"noBirds": "No birds found in this category."
 	},
 	"login": {
 		"title": "Birdwatcher",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -29,7 +29,20 @@
 	"userView": {
 		"sightings": "Havainnot",
 		"noSightings": "Ei havaintoja tälle ajanjaksolle",
-		"failedToLoad": "Havaintojen lataaminen epäonnistui"
+		"failedToLoad": "Havaintojen lataaminen epäonnistui",
+		"compare": "Vertaile"
+	},
+	"compare": {
+		"title": "Vertaile",
+		"titleSelf": "Vertaile koko vuoteen",
+		"titleOther": "Vertaile käyttäjän {{name}} kanssa",
+		"missingThisMonth": "Puuttuvat tässä kuussa",
+		"seenThisMonth": "Nähdyt tässä kuussa",
+		"youHaveTheyDont": "Sinulla on, heillä ei",
+		"theyHaveYouDont": "Heillä on, sinulla ei",
+		"bothHave": "Molemmat ovat nähneet",
+		"selectMonthPrompt": "Valitse kuukausi vertaillaksesi koko vuoteen.",
+		"noBirds": "Ei lintuja tässä kategoriassa."
 	},
 	"login": {
 		"title": "Lintuvahti",


### PR DESCRIPTION
## Summary

Add a 'Compare' view to allow users to compare their bird sightings with others or their own yearly records.

## Changes

- Implement `UserCompare` component with self-comparison (month vs year) and cross-user comparison logic.
- Register the `/groups/:groupId/members/:userId/compare` route.
- Add a 'Compare' button in the `UserView` profile header.
- Add i18n keys and CSS styles for the comparison interface.
- Add E2E tests for the comparison feature in `e2e/user-compare.spec.ts`.
- Used 'varis' (Hooded Crow) as a real bird example in tests.
- Reordered comparison lists so 'Both have' is the last section.

## Verification

- Manually verified the UI layout and responsiveness.
- E2E tests cover core comparison logic (self and cross-user).
